### PR TITLE
Minor typo in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ Sample output in JSON format:
     "Content-Type": "text/html; charset=ISO-8859-1"
   },
   "extracted_text": "Original text"
-}```
+}
+```


### PR DESCRIPTION
The backtick quote marks were showing up in the rendered readme.
